### PR TITLE
Update placeholders to new syntax.

### DIFF
--- a/shortcuts.yml
+++ b/shortcuts.yml
@@ -5,4 +5,5 @@ rfc 1:
   - rfc
   - standard
   examples:
-    1945: Open RFC 1945
+  - arguments: 1945
+    description: Open RFC 1945

--- a/shortcuts.yml
+++ b/shortcuts.yml
@@ -1,8 +1,5 @@
-# Documentation:
-# https://github.com/trovu/trovu.github.io/wiki/Advanced-settings-&-personal-shortcuts#personal-shortcuts
-
 rfc 1:
-  url: https://tools.ietf.org/html/rfc{%query}
+  url: https://tools.ietf.org/html/rfc<query>
   title: RFC (Request for Comments)
   tags:
   - rfc


### PR DESCRIPTION
Placeholder syntax changed from

- `{%query}` to `<query>`.
- `{%query|type=city}` to `<query: {type: city}>`.

(Now using [YAML Flow style](https://www.yaml.info/learn/flowstyle.html).)

Read more: https://trovu.net/docs/shortcuts/url/